### PR TITLE
Fix Line Items deserialization in admin interface

### DIFF
--- a/inc/models/class-payment.php
+++ b/inc/models/class-payment.php
@@ -600,6 +600,14 @@ class Payment extends Base_Model {
 		if (null === $this->line_items) {
 			$line_items = (array) $this->get_meta('wu_line_items');
 
+			// Convert arrays back to Line_Item objects
+			$line_items = array_map(function($item) {
+				if (is_array($item)) {
+					return new \WP_Ultimo\Checkout\Line_Item($item);
+				}
+				return $item;
+			}, $line_items);
+	
 			$this->line_items = array_filter($line_items);
 		}
 


### PR DESCRIPTION
Resolves critical error in admin interface when displaying payment line items.

The issue occurred because line_items were stored as serialized PHP arrays in the database but were not properly converted back to Line_Item objects when retrieved. This caused fatal errors when admin pages tried to call methods like get_product() on array data instead of Line_Item objects.

Changes:
- Modified Payment::get_line_items() to automatically convert arrays to Line_Item objects
- Added proper type checking and conversion in the deserialization process
- Ensures backward compatibility with existing stored data

Fixes admin interface crashes in payment line items display.