### PR TITLE
Fix gateway_customer_id type from integer to string in membership-upd…

### DIFF
--- a/inc/api/schemas/membership-update.php
+++ b/inc/api/schemas/membership-update.php
@@ -130,7 +130,7 @@ return [
 	],
 	'gateway_customer_id'         => [
 		'description' => __('The ID of the customer on the payment gateway database.', 'multisite-ultimate'),
-		'type'        => 'integer',
+		'type'        => 'string',
 		'required'    => false,
 	],
 	'gateway_subscription_id'     => [


### PR DESCRIPTION
…ate schema

The API returns "Bad request - Invalid parameter(s): gateway_customer_id" because the schema defines gateway_customer_id as integer type instead of string.

Gateway customer IDs are typically strings rather than integers in most payment gateways, so this change fixes API validation errors when passing gateway customer IDs.