### PR TITLE
Fix: Complement to #149 – Ensure API-created payment line_items arrays are converted to Line_Item objects #158

### DIFF
--- a/inc/models/class-payment.php
+++ b/inc/models/class-payment.php
@@ -600,6 +600,14 @@ class Payment extends Base_Model {
 		if (null === $this->line_items) {
 			$line_items = (array) $this->get_meta('wu_line_items');
 
+			// Convert arrays back to Line_Item objects
+			$line_items = array_map(function($item) {
+				if (is_array($item)) {
+					return new \WP_Ultimo\Checkout\Line_Item($item);
+				}
+				return $item;
+			}, $line_items);
+	
 			$this->line_items = array_filter($line_items);
 		}
 


### PR DESCRIPTION
## Summary
This PR complements [#149](https://github.com/superdav42/wp-multisite-waas/pull/149) by fixing an additional case where payments created via the API store `line_items` as arrays instead of `WP_Ultimo\Checkout\Line_Item` objects.

Without this conversion, certain admin views, hooks, or calculations may fail or produce inconsistent results.

## Context
- PR #149 addressed object handling for customer/site data during API operations.
- However, for payments created via API, `line_items` can still be saved as **plain arrays** in meta.
- When `Payment::get_line_items()` is called, these arrays cause:
  - PHP warnings/notices when object methods are accessed.
  - Incorrect totals or missing data in the admin payment view.
  - Hook/filter incompatibility for extensions expecting `Line_Item` objects.

## Changes
- **File:** `inc/models/class-payment.php`
- **Method:** `get_line_items()`
- **Added logic**:
  - Map each `line_item` array into a proper `WP_Ultimo\Checkout\Line_Item` instance.
  - Leave items already in object form untouched.
  - Apply `array_filter` to remove any empty/null entries.

## Impact
- **Backward compatible** – works for both legacy object-based storage and array-based storage from API-created payments.
- Fixes admin display and ensures consistent hook behavior.
- No database schema changes.

## Testing
1. Create a payment via the API where `line_items` are stored as arrays.
2. Load the payment in the admin panel – items should now display correctly, without warnings in logs/Query Monitor.
3. Hooks and calculations relying on `Line_Item` objects should now run without errors.

## Review Notes
- Defensive conversion (`is_array($item)`) to avoid touching already valid objects.
- Safe, isolated change with no side effects beyond `get_line_items()` behavior.
